### PR TITLE
added `cleardir` command to empty the out directories

### DIFF
--- a/ERKER2Phenopackets/src/MC4R/Pipeline.py
+++ b/ERKER2Phenopackets/src/MC4R/Pipeline.py
@@ -164,8 +164,8 @@ def pipeline(data_path: str, out_dir_name: str = '', publish: bool = False):
         df = PolarsUtils.map_col(df, map_from='ln_48007_9_3',
                                  map_to='parsed_zygosity_3',
                                  mapping=zygosity_map_erker2phenopackets)
-    df = PolarsUtils.map_col(df, map_from='ln_48007_9_3', map_to='allele_label_3',
-                             mapping=allele_label_map_erker2phenopackets)
+        df = PolarsUtils.map_col(df, map_from='ln_48007_9_3', map_to='allele_label_3',
+                                 mapping=allele_label_map_erker2phenopackets)
 
     # sct_439401001_orpha (diagnosis (ORPHA))
     logger.trace('Diagnosis (ORPHA) column does not require parsing')

--- a/ERKER2Phenopackets/src/utils/__init__.py
+++ b/ERKER2Phenopackets/src/utils/__init__.py
@@ -9,6 +9,8 @@ from .ParsingUtils import parse_date_string_to_protobuf_timestamp, \
     parse_year_month_day_to_iso8601_utc_timestamp, \
     parse_iso8601_utc_to_protobuf_timestamp
 
+from .delete_files_in_folder import delete_files_in_folder
+
 __all__ = [
     'write_file', 'write_files',
 
@@ -19,5 +21,6 @@ __all__ = [
     'parse_date_string_to_iso8601_utc_timestamp', 
     'parse_year_month_day_to_iso8601_utc_timestamp',
     'parse_iso8601_utc_to_protobuf_timestamp',
-    
+
+    'delete_files_in_folder',
 ]

--- a/ERKER2Phenopackets/src/utils/cleardir.py
+++ b/ERKER2Phenopackets/src/utils/cleardir.py
@@ -29,7 +29,7 @@ def clear_dir(all_: bool, experimental: bool, publish: bool):
         logger.info('Deleting published phenopackets')
         delete_files_in_folder(prod_out, json_suffix)
 
-    logger.info(f"Finished clearing directories.")
+    logger.info('Finished clearing directories.')
 
 
 def main():

--- a/ERKER2Phenopackets/src/utils/cleardir.py
+++ b/ERKER2Phenopackets/src/utils/cleardir.py
@@ -43,3 +43,5 @@ def main():
     clear_dir(args.all, args.experimental, args.publish)
 
 
+if __name__ == '__main__':
+    main()

--- a/ERKER2Phenopackets/src/utils/cleardir.py
+++ b/ERKER2Phenopackets/src/utils/cleardir.py
@@ -29,7 +29,7 @@ def clear_dir(all_: bool, experimental: bool, publish: bool):
         logger.info('Deleting published phenopackets')
         delete_files_in_folder(prod_out, json_suffix)
 
-   # logger.info(f"Finished clearing directories.")
+    logger.info(f"Finished clearing directories.")
 
 
 def main():

--- a/ERKER2Phenopackets/src/utils/cleardir.py
+++ b/ERKER2Phenopackets/src/utils/cleardir.py
@@ -29,6 +29,8 @@ def clear_dir(all_: bool, experimental: bool, publish: bool):
         logger.info('Deleting published phenopackets')
         delete_files_in_folder(prod_out, json_suffix)
 
+    logger.info(f'Finished clearing directories.')
+
 
 def main():
     arg_parser = argparse.ArgumentParser(prog='clear_phenopackets',
@@ -51,8 +53,10 @@ def main():
 
     setup_logging(level='TRACE')
 
-    if not (args.all or args.experimental or args.publish):
+    if not args.all and not args.experimental and not args.publish:
+        logger.debug('No tag given, setting deleting experimental to True')
         clear_dir(all_=False, experimental=True, publish=False)
+        return
     clear_dir(all_=args.all, experimental=args.experimental, publish=args.publish)
 
 

--- a/ERKER2Phenopackets/src/utils/cleardir.py
+++ b/ERKER2Phenopackets/src/utils/cleardir.py
@@ -29,7 +29,7 @@ def clear_dir(all_: bool, experimental: bool, publish: bool):
         logger.info('Deleting published phenopackets')
         delete_files_in_folder(prod_out, json_suffix)
 
-    logger.info(f"Finished clearing directories.")
+   # logger.info(f"Finished clearing directories.")
 
 
 def main():

--- a/ERKER2Phenopackets/src/utils/cleardir.py
+++ b/ERKER2Phenopackets/src/utils/cleardir.py
@@ -51,7 +51,7 @@ def main():
 
     args = arg_parser.parse_args()
 
-    setup_logging(level='TRACE')
+    setup_logging(level='INFO')
 
     if not args.all and not args.experimental and not args.publish:
         logger.debug('No tag given, setting deleting experimental to True')

--- a/ERKER2Phenopackets/src/utils/cleardir.py
+++ b/ERKER2Phenopackets/src/utils/cleardir.py
@@ -1,10 +1,30 @@
 import argparse
+import configparser
+from pathlib import Path
+
+from ERKER2Phenopackets.src.utils import delete_files_in_folder
+
+
+def clear_dir(all_: bool, experimental: bool, publish: bool):
+    config = configparser.ConfigParser()
+    config.read('ERKER2Phenopackets/data/config/config.cfg')
+
+    test_out = Path(config.get('Paths', 'test_phenopackets_out_script'))
+    prod_out = Path(config.get('Paths', 'phenopackets_out_script'))
+    json_suffix = '.json'
+
+    if all_:
+        delete_files_in_folder([test_out, prod_out], json_suffix)
+    elif experimental:
+        delete_files_in_folder(test_out, json_suffix)
+    elif publish:
+        delete_files_in_folder(prod_out, json_suffix)
 
 
 def main():
     arg_parser = argparse.ArgumentParser(prog='clear_phenopackets',
                                          description='Removes previously created '
-                                                     'phenopackets.')
+                                                     'phenopackets. Defaults to -e.')
 
     mut_excl_group = arg_parser.add_mutually_exclusive_group()
 
@@ -18,13 +38,8 @@ def main():
                                      'out/experimental_phenopackets and '
                                      'out/phenopackets')
 
-    arg_parser.add_argument('-p', '--publish', action='store_true',
-                            help='Write phenopackets to out instead of test')
-
-    # Add positional arguments
-    arg_parser.add_argument('data_path', help='The path to the data')
-    arg_parser.add_argument('out_dir_name', nargs='?', default='',
-                            help='The name of the output directory')
-
-    # Parse the arguments
     args = arg_parser.parse_args()
+
+    clear_dir(args.all, args.experimental, args.publish)
+
+

--- a/ERKER2Phenopackets/src/utils/cleardir.py
+++ b/ERKER2Phenopackets/src/utils/cleardir.py
@@ -2,10 +2,16 @@ import argparse
 import configparser
 from pathlib import Path
 
+from loguru import logger
+
 from ERKER2Phenopackets.src.utils import delete_files_in_folder
+from ERKER2Phenopackets.src.logging_ import setup_logging
 
 
 def clear_dir(all_: bool, experimental: bool, publish: bool):
+    logger.trace(f'Called clear_dir() with args: {all_=}, {experimental=}, {publish=}')
+
+    logger.trace('Reading config file')
     config = configparser.ConfigParser()
     config.read('ERKER2Phenopackets/data/config/config.cfg')
 
@@ -14,10 +20,13 @@ def clear_dir(all_: bool, experimental: bool, publish: bool):
     json_suffix = '.json'
 
     if all_:
+        logger.info('Deleting all phenopackets')
         delete_files_in_folder([test_out, prod_out], json_suffix)
     elif experimental:
+        logger.info('Deleting experimental phenopackets')
         delete_files_in_folder(test_out, json_suffix)
     elif publish:
+        logger.info('Deleting published phenopackets')
         delete_files_in_folder(prod_out, json_suffix)
 
 
@@ -39,6 +48,8 @@ def main():
                                      'out/phenopackets')
 
     args = arg_parser.parse_args()
+
+    setup_logging(level='TRACE')
 
     clear_dir(args.all, args.experimental, args.publish)
 

--- a/ERKER2Phenopackets/src/utils/cleardir.py
+++ b/ERKER2Phenopackets/src/utils/cleardir.py
@@ -51,7 +51,9 @@ def main():
 
     setup_logging(level='TRACE')
 
-    clear_dir(args.all, args.experimental, args.publish)
+    if not (args.all or args.experimental or args.publish):
+        clear_dir(all_=False, experimental=True, publish=False)
+    clear_dir(all_=args.all, experimental=args.experimental, publish=args.publish)
 
 
 if __name__ == '__main__':

--- a/ERKER2Phenopackets/src/utils/cleardir.py
+++ b/ERKER2Phenopackets/src/utils/cleardir.py
@@ -1,0 +1,30 @@
+import argparse
+
+
+def main():
+    arg_parser = argparse.ArgumentParser(prog='clear_phenopackets',
+                                         description='Removes previously created '
+                                                     'phenopackets.')
+
+    mut_excl_group = arg_parser.add_mutually_exclusive_group()
+
+    mut_excl_group.add_argument('-e', '--experimental', action='store_true',
+                                help='Deletes all phenopackets in '
+                                     'out/experimental_phenopackets')
+    mut_excl_group.add_argument('-p', '--publish', action='store_true',
+                                help='deletes all phenopackets in out/phenopackets')
+    mut_excl_group.add_argument('-a', '--all', action='store_true',
+                                help='Deletes all phenopackets in both '
+                                     'out/experimental_phenopackets and '
+                                     'out/phenopackets')
+
+    arg_parser.add_argument('-p', '--publish', action='store_true',
+                            help='Write phenopackets to out instead of test')
+
+    # Add positional arguments
+    arg_parser.add_argument('data_path', help='The path to the data')
+    arg_parser.add_argument('out_dir_name', nargs='?', default='',
+                            help='The name of the output directory')
+
+    # Parse the arguments
+    args = arg_parser.parse_args()

--- a/ERKER2Phenopackets/src/utils/cleardir.py
+++ b/ERKER2Phenopackets/src/utils/cleardir.py
@@ -29,7 +29,7 @@ def clear_dir(all_: bool, experimental: bool, publish: bool):
         logger.info('Deleting published phenopackets')
         delete_files_in_folder(prod_out, json_suffix)
 
-    logger.info(f'Finished clearing directories.')
+    logger.info(f"Finished clearing directories.")
 
 
 def main():

--- a/ERKER2Phenopackets/src/utils/delete_files_in_folder.py
+++ b/ERKER2Phenopackets/src/utils/delete_files_in_folder.py
@@ -37,5 +37,6 @@ def delete_files_in_folder(dirs: Union[Path, List[Path]], file_extension: str = 
             elif file.is_dir():
                 logger.trace(f"Found directory {file}")
                 delete_files_in_folder(file, file_extension)
+                file.unlink()
 
     logger.info("Finished the delete_files_in_folder method")

--- a/ERKER2Phenopackets/src/utils/delete_files_in_folder.py
+++ b/ERKER2Phenopackets/src/utils/delete_files_in_folder.py
@@ -34,5 +34,8 @@ def delete_files_in_folder(dirs: Union[Path, List[Path]], file_extension: str = 
                 if file_extension and file_extension in file.suffix:
                     logger.trace(f"Deleting the file {file}")
                     file.unlink()
+            elif file.is_dir():
+                logger.trace(f"Found directory {file}")
+                delete_files_in_folder(file, file_extension)
 
     logger.info("Finished the delete_files_in_folder method")

--- a/ERKER2Phenopackets/src/utils/delete_files_in_folder.py
+++ b/ERKER2Phenopackets/src/utils/delete_files_in_folder.py
@@ -18,10 +18,10 @@ def delete_files_in_folder(dirs: Union[Path, List[Path]], file_extension: str = 
         dirs = [dirs]
 
     if file_extension:
-        logger.info(f"Starting the delete_files_in_folder method with "
-                    f"file extension {file_extension}")
+        logger.trace(f"Starting the delete_files_in_folder method with "
+                     f"file extension {file_extension}")
     else:
-        logger.info("Starting the delete_files_in_folder method")
+        logger.trace("Starting the delete_files_in_folder method")
 
     for directory in dirs:
         logger.info(f"Starting deletion in directory: {directory}")
@@ -39,4 +39,4 @@ def delete_files_in_folder(dirs: Union[Path, List[Path]], file_extension: str = 
                 delete_files_in_folder(file, file_extension)
                 file.rmdir()
 
-    logger.info("Finished the delete_files_in_folder method")
+    logger.trace("Finished the delete_files_in_folder method")

--- a/ERKER2Phenopackets/src/utils/delete_files_in_folder.py
+++ b/ERKER2Phenopackets/src/utils/delete_files_in_folder.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+from typing import Union, List
+from loguru import logger
+
+
+def delete_files_in_folder(dirs: Union[Path, List[Path]], file_extension: str = None):
+    """Deletes all files in a folder
+
+    This function deletes all files in a folder. If a file extension is given,
+    only files with that file extension are deleted.
+
+    :param dirs: Path to the folder or a list of paths to folders
+    :type dirs: Union[Path, List[Path]]
+    :param file_extension: File extension of the files that should be deleted
+    :type file_extension: str
+    """
+    if isinstance(dirs, Path):
+        dirs = [dirs]
+
+    if file_extension:
+        logger.info(f"Starting the delete_files_in_folder method with "
+                    f"file extension {file_extension}")
+    else:
+        logger.info("Starting the delete_files_in_folder method")
+
+    for directory in dirs:
+        logger.info(f"Checking the directory {directory}")
+        for file in directory.iterdir():
+            if file.is_file():
+                if file_extension and file_extension in file.suffix:
+                    logger.trace(f"Deleting the file {file}")
+                    file.unlink()
+
+    logger.info("Finished the delete_files_in_folder method")

--- a/ERKER2Phenopackets/src/utils/delete_files_in_folder.py
+++ b/ERKER2Phenopackets/src/utils/delete_files_in_folder.py
@@ -37,6 +37,5 @@ def delete_files_in_folder(dirs: Union[Path, List[Path]], file_extension: str = 
             elif file.is_dir():
                 logger.trace(f"Found directory {file}")
                 delete_files_in_folder(file, file_extension)
-                file.unlink()
 
     logger.info("Finished the delete_files_in_folder method")

--- a/ERKER2Phenopackets/src/utils/delete_files_in_folder.py
+++ b/ERKER2Phenopackets/src/utils/delete_files_in_folder.py
@@ -24,9 +24,13 @@ def delete_files_in_folder(dirs: Union[Path, List[Path]], file_extension: str = 
         logger.info("Starting the delete_files_in_folder method")
 
     for directory in dirs:
-        logger.info(f"Checking the directory {directory}")
+        logger.info(f"Starting deletion in directory: {directory}")
         for file in directory.iterdir():
+            logger.trace('iteration')
             if file.is_file():
+                logger.trace(f"Found file {file}")
+                logger.debug(f'{file_extension=}, '
+                             f'{(file_extension in file.suffix)=}')
                 if file_extension and file_extension in file.suffix:
                     logger.trace(f"Deleting the file {file}")
                     file.unlink()

--- a/ERKER2Phenopackets/src/utils/delete_files_in_folder.py
+++ b/ERKER2Phenopackets/src/utils/delete_files_in_folder.py
@@ -37,5 +37,6 @@ def delete_files_in_folder(dirs: Union[Path, List[Path]], file_extension: str = 
             elif file.is_dir():
                 logger.trace(f"Found directory {file}")
                 delete_files_in_folder(file, file_extension)
+                file.rmdir()
 
     logger.info("Finished the delete_files_in_folder method")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ERKER2Phenopackets"
-version = "1.1.4"
+version = "1.1.6"
 description = "Mapping the ERKER Dataset onto the Phenopackets Schema"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -31,6 +31,7 @@ test = ["pytest==7.1.2", "ruff", "isort", "coverage", "pytest-cov"]
 [project.scripts]
 pipeline = "ERKER2Phenopackets.src.MC4R.Pipeline:main"
 validate = "ERKER2Phenopackets.src.utils.PhenopacketValidation:main"
+cleardir = "ERKER2Phenopackets.src.utils.cleardir:main"
 
 [build-system]
 # These are the assumed default build requirements from pip:


### PR DESCRIPTION
```
usage: clear_phenopackets [-h] [-e | -p | -a]

Removes previously created phenopackets. Defaults to -e.

options:
  -h, --help          show this help message and exit
  -e, --experimental  Deletes all phenopackets in out/experimental_phenopackets
  -p, --publish       deletes all phenopackets in out/phenopackets
  -a, --all           Deletes all phenopackets in both out/experimental_phenopackets and out/phenopackets

```